### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/spec/spec-helper.js
+++ b/spec/spec-helper.js
@@ -21,14 +21,14 @@ export function waitsForTimeout(ms = 50) {
 }
 
 export function getActivationPromise() {
-    return atom.packages.activatePackage('neovimbed').then(async package => {
+    return atom.packages.activatePackage('neovimbed').then(async pack => {
         atom.workspace.destroyActivePaneItem();
-        await package.mainModule.initialisationPromise;
-        window.nvim = package.mainModule.nvim;
+        await pack.mainModule.initialisationPromise;
+        window.nvim = pack.mainModule.nvim;
         // TODO: This may be a bad idea and it's actually something that
         // should be handled and have test cases for
         await window.nvim.command('set noswapfile');
-        return package.mainModule;
+        return pack.mainModule;
     });
 }
 


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!